### PR TITLE
[TASK][PRS-358] improve error-handling on hubspot forms

### DIFF
--- a/Classes/Form/Finisher/HubSpotFinisher.php
+++ b/Classes/Form/Finisher/HubSpotFinisher.php
@@ -39,10 +39,8 @@ class HubSpotFinisher extends AbstractFinisher
         $hubspotFormId = $formRuntime->getFormDefinition()->getIdentifier();
         $formSubmitResponse = $this->hubspotFormService->submit($hubspotFormId, $hubspotFormData);
 
-        if (!empty($formSubmitResponse['inlineMessage'])) {
-            $formRuntime->getResponse()->setContent($formSubmitResponse['inlineMessage']);
-            $this->finisherContext->cancel();
-        }
+        $formRuntime->getResponse()->setContent($formSubmitResponse);
+        $this->finisherContext->cancel();
     }
 
     /**


### PR DESCRIPTION
2 Änderungen:
1. Fehler bei der Formularübermittlung werden gelogged
2. Im Falle einer Exception wird die hübsch gestylte Fehlermeldung von Hubspot auf der Webseite ausgegeben