### PR TITLE
[TASK][PRS-358] add missing case for form response handling

### DIFF
--- a/Classes/Service/HubspotFormService.php
+++ b/Classes/Service/HubspotFormService.php
@@ -160,6 +160,8 @@ class HubspotFormService
         try {
             $apiResponse = $this->forms->submit($this->settings['api']['portalId'], $formIdentifier, $formData);
             switch ($code = $apiResponse->getStatusCode()) {
+                case 200:
+                    return '';
                 case 204:
                     return $this->getFormByIdentifier($formIdentifier)['inlineMessage'];
                 default:


### PR DESCRIPTION
I wrongly assumed that if no inline message was set, the response would still be 204.
Instead it is 200.