### PR TITLE
[TASK][PRS-372] add super-type 'FormElement' to hidden fields

### DIFF
--- a/Configuration/Settings.Form.yaml
+++ b/Configuration/Settings.Form.yaml
@@ -49,6 +49,9 @@ Neos:
           'Onedrop.Form.Hubspot:Component.Atom.DatePicker':
             superTypes:
               'Neos.Form:DatePicker': true
+          'Onedrop.Form.Hubspot:Component.Atom.Hidden':
+            superTypes:
+              'Neos.Form:FormElement': true
 
           'Onedrop.Form.Hubspot:Component.Atom.RecaptchaV2':
             superTypes:


### PR DESCRIPTION
Default value was not set for hidden fields because supertype was missing.